### PR TITLE
fix duplicate content name and missing required restartPolicy

### DIFF
--- a/examples/1-job-tmp-cleanup.yaml
+++ b/examples/1-job-tmp-cleanup.yaml
@@ -8,10 +8,11 @@ spec:
     spec:
       template:
         spec:
+          restartPolicy: Never
 ################################################################
 # cleanup shared /tmp before downloading content
           initContainers:
-            - name: content
+            - name: cleanup-tmp-folder
               image: alpine
               command:
                 - "/bin/sh"


### PR DESCRIPTION
This fixes https://github.com/BretFisher/initcontainers/issues/1

❯ k apply -f 1-job-tmp-cleanup.yaml
cronjob.batch/content unchanged

<MB081>~/kubectl/initcontainers/examples   fix_first_example 🛤️  ×4 via 💎 v3.2.2
❯ k get cronjob
NAME      SCHEDULE       TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
content   */60 * * * *   <none>     False     0        <none>          5m45s

❯  k get cronjob.batch/content -o yaml | grep -i restartPolicy:
          restartPolicy: Never